### PR TITLE
Dynamically show days since trending & cache by trending cfg

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -65,7 +65,7 @@ DJANGO_APPS = [
     "django.contrib.messages",
     "django.contrib.sitemaps",
     "django.contrib.staticfiles",
-    # "django.contrib.humanize", # Handy template tags
+    "django.contrib.humanize",
     "django.contrib.admin",
     "django.forms",
 ]
@@ -198,6 +198,7 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "django_apps.utils.context_processors.settings_context",
+                "constance.context_processors.config",
             ],
         },
     }

--- a/django_apps/core/views.py
+++ b/django_apps/core/views.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from cacheops import cached_as
 from constance import config
+from constance.backends.database.models import Constance
 from django.core.paginator import Paginator
 from django.views.generic.base import TemplateView
 from django.views.generic.detail import DetailView
@@ -94,6 +95,9 @@ class TrendingRepositoriesView(MetadataMixin, ListView):
     def get_queryset(self):
         return trending_repositories()
 
+    def get_meta_description(self, context=None):
+        return f"Trending Django projects in the past {config.DAYS_SINCE_TRENDING} days"
+
 
 class TopRepositoriesView(MetadataMixin, ListView):
     paginate_by = 25
@@ -136,8 +140,11 @@ class TrendingProfilesView(MetadataMixin, ListView):
     def get_queryset(self):
         return trending_profiles()
 
+    def get_meta_description(self, context=None):
+        return f"Trending Django projects in the past {config.DAYS_SINCE_TRENDING} days"
 
-@cached_as(RepositoryStars, timeout=60 * 60 * 24)
+
+@cached_as(RepositoryStars, Constance, timeout=60 * 60 * 24)
 def trending_repositories(**filters):
     trending = []
     for repo in Repository.valid.filter(stars__gte=20, **filters):
@@ -166,7 +173,7 @@ def most_followed_profiles():
     return Profile.objects.filter(id__in=profile_ids).order_by("-followers")
 
 
-@cached_as(Contributor, timeout=60 * 60 * 24)
+@cached_as(Contributor, Constance, timeout=60 * 60 * 24)
 def trending_profiles():
     # Contributed to a Django project
     # Sorted by most stars in the past two weeks

--- a/django_apps/templates/core/trending_profiles.html
+++ b/django_apps/templates/core/trending_profiles.html
@@ -1,4 +1,5 @@
 {% extends "core/base.html" %}
+{% load humanize %}
 {% load user_agents %}
 
 {% block content %}
@@ -6,7 +7,7 @@
   <div class="flex flex-wrap self-start mt-3 mb-10 text-sm lg:text-lg gap-2">
     <div class="badge badge-lg badge-primary">Trending profiles</div>
     {% if not request|is_mobile and not request|is_tablet %}
-    <div class="badge badge-lg badge-primary">Engineers that have gained the most followers in the past two weeks</div>
+    <div class="badge badge-lg badge-primary">Engineers that have gained the most followers in the past {{ config.DAYS_SINCE_TRENDING | apnumber }} days</div>
     {% endif %}
   </div>
 

--- a/django_apps/templates/core/trending_repositories.html
+++ b/django_apps/templates/core/trending_repositories.html
@@ -1,18 +1,19 @@
 {% extends "core/base.html" %}
+{% load humanize %}
 {% load user_agents %}
 
 {% block content %}
-<div class="flex flex-col self-center items-center p-4 lg:p-6 w-full lg:w-11/12">
+<div class="flex flex-col items-center self-center w-full p-4 lg:p-6 lg:w-11/12">
   <div class="flex flex-wrap self-start mt-3 mb-10 text-sm lg:text-lg gap-2">
     <div class="badge badge-lg badge-primary">Trending repositories</div>
     {% if request|is_mobile or request|is_tablet %}
     <div class="badge badge-lg badge-primary">Repositories with the most stars</div>
     {% else %}
-    <div class="badge badge-lg badge-primary">Repositories with the most stars in the past 2 weeks</div>
+    <div class="badge badge-lg badge-primary">Repositories with the most stars in the past {{ config.DAYS_SINCE_TRENDING | apnumber }} days</div>
     {% endif %}
   </div>
 
-  <table class="table w-full leading-6 mb-5">
+  <table class="table w-full mb-5 leading-6">
     <thead>
       <tr>
         <th class="hidden xl:block">Rank</th>


### PR DESCRIPTION
Dynamically cache the trending profiles and repos on the constance
config value as well as the repos and contributors models. If the config
changes purge the cache.

Also show the days since trending in badges and meta info by retrieving
data from constance.
