### PR TITLE
feat: make trending page show stars proportional to total

### DIFF
--- a/django_apps/core/templatetags/wtf_tags.py
+++ b/django_apps/core/templatetags/wtf_tags.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def to_percent(obj):
+    if obj:
+        return f"{obj:.2%}"
+    return obj

--- a/django_apps/core/views.py
+++ b/django_apps/core/views.py
@@ -157,11 +157,12 @@ def trending_repositories(**filters):
         stars_in_the_last_week = repo.stars_since(
             timedelta(days=config.DAYS_SINCE_TRENDING)
         )
-        setattr(repo, "stars_lately", stars_in_the_last_week)
         if stars_in_the_last_week > 0:
+            setattr(repo, "stars_lately", stars_in_the_last_week)
+            setattr(repo, "stars_quota", repo.stars_lately / repo.stars)
             trending.append(repo)
 
-    return sorted(trending, key=lambda e: e.stars_lately, reverse=True)
+    return sorted(trending, key=lambda e: e.stars_quota, reverse=True)
 
 
 @cached_as(Contributor, timeout=60 * 60 * 24)

--- a/django_apps/templates/core/trending_repositories.html
+++ b/django_apps/templates/core/trending_repositories.html
@@ -1,6 +1,5 @@
 {% extends "core/base.html" %}
-{% load humanize %}
-{% load user_agents %}
+{% load humanize user_agents wtf_tags %}
 
 {% block content %}
 <div class="flex flex-col items-center self-center w-full p-4 lg:p-6 lg:w-11/12">
@@ -9,7 +8,7 @@
     {% if request|is_mobile or request|is_tablet %}
     <div class="badge badge-lg badge-primary">Repositories with the most stars</div>
     {% else %}
-    <div class="badge badge-lg badge-primary">Repositories with the most new stars in the past {{ config.DAYS_SINCE_TRENDING | apnumber }} days</div>
+    <div class="badge badge-lg badge-primary">Repositories with proportionally largest increase in stars for the last {{ config.DAYS_SINCE_TRENDING | apnumber }} days</div>
     {% endif %}
   </div>
 
@@ -22,7 +21,7 @@
         {% if request|is_mobile or request|is_tablet %}
         <th>Stars</th>
         {% else %}
-        <th>Number of new stars</th>
+        <th>% stars increase (new stars)</th>
         {% endif %}
       </tr>
     </thead>
@@ -50,9 +49,9 @@
             {{ repo.truncated_description|truncatechars:50 }}
           </a>
         </td>
-        <td class="text-center">
+        <td class="text-right">
           <a href="{{ url }}" target="_blank">
-            {{ repo.stars_lately }}
+            <strong>{{ repo.stars_quota | to_percent }}</strong> ({{ repo.stars_lately }})
           </a>
         </td>
         {% endwith %}


### PR DESCRIPTION
Show proportional stars to the repo size in percentage instead of the
absolute number of new stars which favors large repositories.
