### PR TITLE
fix: handle DataError on Github repo updates

### DIFF
--- a/django_wtf/core/github_tasks.py
+++ b/django_wtf/core/github_tasks.py
@@ -95,7 +95,7 @@ def _update_or_create_repo(repository_data):
         )
         log_action(repository_stars, created)
     except DataError:
-        logging.exception(f"DataError for {repository=}")
+        logging.exception(f"DataError for {repository_data=}")
 
 
 @app.task()


### PR DESCRIPTION
```
  File "/app/django_wtf/core/github_tasks.py", line 98, in _update_or_create_repo                                                                                                                               │
    logging.exception(f"DataError for {repository=}")                                                                                                                                                           │
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                            │
UnboundLocalError: cannot access local variable 'repository' where it is not associated with a value                                                                                                            │

```