### PR TITLE
fix: use the since parameter for detail view

### DIFF
--- a/django_wtf/core/views/detail_view.py
+++ b/django_wtf/core/views/detail_view.py
@@ -13,7 +13,7 @@ class RepoDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         obj = self.get_object()
-        stars_since_1m = obj.stars_since(td=timedelta(days=30))
+        stars_since_1m = obj.stars_since(since=timedelta(days=30))
         context["stars_increase_monthly_percent"] = stars_since_1m / obj.stars * 100.0
         return context
 

--- a/django_wtf/templates/core/repository_detail.html
+++ b/django_wtf/templates/core/repository_detail.html
@@ -1,12 +1,10 @@
 {% extends "core/base.html" %}
 {% block content %}
     <div class="flex-col content-center self-center w-full mb-5 lg:mt-5 lg:flex lg:w-7/12">
-        <div class="flex">
+        <div class="flex mt-10 mb-10">
             <div>
-                <h1 class="mt-6 text-6xl hover:brightness-125">
-                    <a href="{{ object.github_url }}">{{ object.full_name }}</a>
-                </h1>
-                <h3 class="mt-3 text-xl">{{ object.description }}</h3>
+                <a class="mt-6 text-4xl link link-hover" href="{{ object.github_url }}">{{ object.full_name }}</a>
+                <p class="mt-3 text-xl">{{ object.description }}</p>
                 <div class="my-3">
                     {% for topic in object.topics %}<div class="ml-1 badge badge-outline">{{ topic }}</div>{% endfor %}
                 </div>


### PR DESCRIPTION
TypeError: Repository.stars_since() got an unexpected keyword argument 'td'
